### PR TITLE
Introduce a new `FiberRefs` implementation

### DIFF
--- a/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
@@ -40,8 +40,8 @@ object BenchmarkUtil extends Runtime[Any] { self =>
   }
 
   private object NoFiberRootsRuntime extends Runtime[Any] {
-    val environment  = Runtime.default.environment
-    val fiberRefs    = Runtime.default.fiberRefs
-    val runtimeFlags = RuntimeFlags(RuntimeFlag.CooperativeYielding, RuntimeFlag.Interruption)
+    override val environment: ZEnvironment[Any] = Runtime.default.environment
+    override val fiberRefs: FiberRefs           = Runtime.default.fiberRefs
+    override val runtimeFlags: RuntimeFlags     = RuntimeFlags(RuntimeFlag.CooperativeYielding, RuntimeFlag.Interruption)
   }
 }

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -191,7 +191,7 @@ trait Runtime[+R] { self =>
     private def makeFiber[E, A](
       zio: ZIO[R, E, A]
     )(implicit trace: Trace, unsafe: Unsafe): internal.FiberRuntime[E, A] = {
-      val fiberId   = FiberId.make(trace)
+      val fiberId = FiberId.make(trace)
       // TODO Jules: Inspect deeper
       val fiberRefs = self.fiberRefs.updatedAs(fiberId)(FiberRef.currentEnvironment, environment)
       val fiber     = FiberRuntime[E, A](fiberId, fiberRefs.forkAs(fiberId), runtimeFlags)
@@ -231,9 +231,9 @@ object Runtime extends RuntimePlatformSpecific {
     runtimeFlags0: RuntimeFlags
   ): Runtime[R] =
     new Runtime[R] {
-      val environment           = r
-      override val fiberRefs    = fiberRefs0
-      override val runtimeFlags = runtimeFlags0
+      override final val environment: ZEnvironment[R] = r
+      override final val fiberRefs: FiberRefs         = fiberRefs0
+      override final val runtimeFlags: RuntimeFlags   = runtimeFlags0
     }
 
   /**
@@ -328,11 +328,10 @@ object Runtime extends RuntimePlatformSpecific {
     }
   }
 
-  class Proxy[+R](underlying: Runtime[R]) extends Runtime[R] {
-    def environment = underlying.environment
-    def fiberRefs   = underlying.fiberRefs
-
-    def runtimeFlags = underlying.runtimeFlags
+  final class Proxy[+R](underlying: Runtime[R]) extends Runtime[R] {
+    override def environment: ZEnvironment[R] = underlying.environment
+    override def fiberRefs: FiberRefs         = underlying.fiberRefs
+    override def runtimeFlags: RuntimeFlags   = underlying.runtimeFlags
   }
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -472,7 +472,7 @@ sealed trait ZIO[-R, +E, +A]
    * `FiberRef` values.
    */
   def diffFiberRefs(implicit trace: Trace): ZIO[R, E, (FiberRefs.Patch, A)] =
-    summarized(ZIO.getFiberRefs)(FiberRefs.Patch.diff)
+    summarized(ZIO.getFiberRefs)(_ diff _)
 
   /**
    * Returns an effect that is always interruptible, but whose interruption will
@@ -2541,7 +2541,7 @@ sealed trait ZIO[-R, +E, +A]
             )
             .forkDaemon
 
-        fork(self, false).zip(fork(that, true)).flatMap { case (left, right) =>
+        (fork(self, side = false) zip fork(that, side = true)).flatMap { case (left, right) =>
           restore(promise.await).foldCauseZIO(
             cause =>
               left.interruptFork *> right.interruptFork *>


### PR DESCRIPTION
Conclusion: not convinced that this implementation would improve performances because the 2 implementations of `FiberRefs` could break the monomorphic nature of the current implementation, which could hurt JIT optimisations (note that I can be totally wrong here)

See also https://gist.github.com/djspiewak/464c11307cabc80171c90397d4ec34ef#keep-things-monomorphic-or-bimorphic